### PR TITLE
:sparkles: can respond to request events directly

### DIFF
--- a/src/mirai-api-http/resp.ts
+++ b/src/mirai-api-http/resp.ts
@@ -1,29 +1,57 @@
 import MiraiApiHttp from "./index";
 import { EventType } from "..";
 
+enum NewFriendRequestEventEnum {
+  "allow",
+  "deny",
+  "black",
+}
+enum MemberJoinRequestEventEnum {
+  "allow",
+  "deny",
+  "ignore",
+  "deny-black",
+  "ignore-black",
+}
+enum DefaultRequestEventEnum {
+  "allow",
+  "deny",
+}
+
+const operations = {
+  NewFriendRequestEvent: NewFriendRequestEventEnum,
+  MemberJoinRequestEvent: MemberJoinRequestEventEnum,
+  BotInvitedJoinGroupRequestEvent: DefaultRequestEventEnum,
+};
+
+export type RequestEventOperation<
+  T extends EventType.RequestEvent["type"]
+> = keyof typeof operations[T];
+
 /**
  * https://github.com/project-mirai/mirai-api-http/blob/master/EventType.md
  * EventType 中的请求
  * resp.xxx 以与 mirai-api-http URL 保持一致
  */
 export class Resp {
-  /**
-   * 将请求事件类型映射到合适的响应方法
-   */
-  mapper: {
-    [type in EventType.RequestEvent["type"]]: (
-      event: EventType.EventMap[type],
-      operate: EventType.EventMap[type]["operations"][number],
-      message?: string
-    ) => Promise<void>;
-  };
+  constructor(private api: MiraiApiHttp) {}
 
-  constructor(private api: MiraiApiHttp) {
-    this.mapper = {
-      NewFriendRequestEvent: this.newFriendRequest,
-      MemberJoinRequestEvent: this.memberJoinRequest,
-      BotInvitedJoinGroupRequestEvent: this.botInvitedJoinGroupRequest,
-    };
+  async _request<E extends EventType.RequestEvent>(
+    event: E,
+    operate: keyof typeof operations[E["type"]],
+    message = ""
+  ) {
+    await this.api.axios.post(
+      `/resp/${event.type[0].toLowerCase()}${event.type.substring(1)}`,
+      {
+        sessionKey: this.api.sessionKey,
+        eventId: event.eventId,
+        fromId: event.fromId,
+        groupId: event.groupId,
+        operate: operations[event.type][operate as any],
+        message,
+      }
+    );
   }
 
   /**
@@ -32,19 +60,12 @@ export class Resp {
    * @param operate 操作 allow 同意添加好友, deny 拒绝添加好友, black 拒绝添加好友并添加黑名单，不再接收该用户的好友申请
    * @param message 响应消息
    */
-  async newFriendRequest(
+  newFriendRequest(
     event: EventType.NewFriendRequestEvent,
-    operate: typeof event["operations"][number],
-    message = ""
+    operate: keyof typeof operations[typeof event["type"]],
+    message?: string
   ) {
-    await this.api.axios.post("/resp/newFriendRequestEvent", {
-      sessionKey: this.api.sessionKey,
-      eventId: event.eventId,
-      fromId: event.fromId,
-      groupId: event.groupId,
-      operate: event.operations.indexOf(operate),
-      message,
-    });
+    return this._request(event, operate, message);
   }
 
   /**
@@ -55,17 +76,10 @@ export class Resp {
    */
   async memberJoinRequest(
     event: EventType.MemberJoinRequestEvent,
-    operate: typeof event["operations"][number],
-    message = ""
+    operate: keyof typeof operations[typeof event["type"]],
+    message?: string
   ) {
-    await this.api.axios.post("/resp/memberJoinRequestEvent", {
-      sessionKey: this.api.sessionKey,
-      eventId: event.eventId,
-      fromId: event.fromId,
-      groupId: event.groupId,
-      operate: event.operations.indexOf(operate),
-      message,
-    });
+    return this._request(event, operate, message);
   }
 
   /**
@@ -76,16 +90,9 @@ export class Resp {
    */
   async botInvitedJoinGroupRequest(
     event: EventType.BotInvitedJoinGroupRequestEvent,
-    operate: typeof event["operations"][number],
-    message = ""
+    operate: keyof typeof operations[typeof event["type"]],
+    message?: string
   ) {
-    await this.api.axios.post("/resp/botInvitedJoinGroupRequestEvent", {
-      sessionKey: this.api.sessionKey,
-      eventId: event.eventId,
-      fromId: event.fromId,
-      groupId: event.groupId,
-      operate: event.operations.indexOf(operate),
-      message,
-    });
+    return this._request(event, operate, message);
   }
 }

--- a/src/mirai-api-http/resp.ts
+++ b/src/mirai-api-http/resp.ts
@@ -1,46 +1,15 @@
 import MiraiApiHttp from "./index";
 import { EventType } from "..";
 
-enum NewFriendRequestEventEnum {
-  "allow",
-  "deny",
-  "black",
-}
-enum MemberJoinRequestEventEnum {
-  "allow",
-  "deny",
-  "ignore",
-  "deny-black",
-  "ignore-black",
-}
-enum DefaultRequestEventEnum {
-  "allow",
-  "deny",
-}
-
-const operations = {
-  NewFriendRequestEvent: NewFriendRequestEventEnum,
-  MemberJoinRequestEvent: MemberJoinRequestEventEnum,
-  BotInvitedJoinGroupRequestEvent: DefaultRequestEventEnum,
-};
-
-export type RequestEventOperation<
-  T extends EventType.RequestEvent["type"]
-> = keyof typeof operations[T];
-
 /**
  * https://github.com/project-mirai/mirai-api-http/blob/master/EventType.md
  * EventType 中的请求
- * resp.xxx 以与 mirai-api-http URL 保持一致
+ * resp.xxx 与 mirai-api-http URL 保持一致
  */
 export class Resp {
   constructor(private api: MiraiApiHttp) {}
 
-  async _request<E extends EventType.RequestEvent>(
-    event: E,
-    operate: keyof typeof operations[E["type"]],
-    message = ""
-  ) {
+  async _request(event: EventType.RequestEvent, operate: number, message = "") {
     await this.api.axios.post(
       `/resp/${event.type[0].toLowerCase()}${event.type.substring(1)}`,
       {
@@ -48,7 +17,7 @@ export class Resp {
         eventId: event.eventId,
         fromId: event.fromId,
         groupId: event.groupId,
-        operate: operations[event.type][operate as any],
+        operate,
         message,
       }
     );
@@ -57,13 +26,13 @@ export class Resp {
   /**
    * 响应新朋友请求
    * @param event 请求的事件
-   * @param operate 操作 allow 同意添加好友, deny 拒绝添加好友, black 拒绝添加好友并添加黑名单，不再接收该用户的好友申请
+   * @param operate 0 同意添加好友, 1 拒绝添加好友, 2 拒绝添加好友并添加黑名单，不再接收该用户的好友申请
    * @param message 响应消息
    */
   newFriendRequest(
     event: EventType.NewFriendRequestEvent,
-    operate: keyof typeof operations[typeof event["type"]],
-    message?: string
+    operate: 0 | 1 | 2,
+    message = ""
   ) {
     return this._request(event, operate, message);
   }
@@ -71,13 +40,13 @@ export class Resp {
   /**
    * 响应新入群请求
    * @param event 请求的事件
-   * @param operate 操作 allow 同意入群, deny 拒绝入群, ignore 忽略请求, deny-black 拒绝入群并添加黑名单，不再接收该用户的入群申请, ignore-black 忽略入群并添加黑名单，不再接收该用户的入群申请
+   * @param operate 操作: 0 同意入群, 1 拒绝入群, 2 忽略请求, 3 拒绝入群并添加黑名单，不再接收该用户的入群申请, 4 忽略入群并添加黑名单，不再接收该用户的入群申请
    * @param message 响应消息
    */
-  async memberJoinRequest(
+  memberJoinRequest(
     event: EventType.MemberJoinRequestEvent,
-    operate: keyof typeof operations[typeof event["type"]],
-    message?: string
+    operate: 0 | 1 | 2 | 3 | 4,
+    message = ""
   ) {
     return this._request(event, operate, message);
   }
@@ -85,13 +54,13 @@ export class Resp {
   /**
    * 响应被邀请入群申请
    * @param event 请求的事件
-   * @param operate 操作 allow 同意邀请, deny 拒绝邀请
+   * @param operate 操作：1 同意邀请, 2 拒绝邀请
    * @param message 响应消息
    */
-  async botInvitedJoinGroupRequest(
+  botInvitedJoinGroupRequest(
     event: EventType.BotInvitedJoinGroupRequestEvent,
-    operate: keyof typeof operations[typeof event["type"]],
-    message?: string
+    operate: 0 | 1,
+    message = ""
   ) {
     return this._request(event, operate, message);
   }

--- a/src/mirai-api-http/resp.ts
+++ b/src/mirai-api-http/resp.ts
@@ -2,6 +2,19 @@ import MiraiApiHttp from "./index";
 import { EventType } from "..";
 
 /**
+ * 0 同意添加好友, 1 拒绝添加好友, 2 拒绝添加好友并添加黑名单，不再接收该用户的好友申请
+ */
+export type NewFriendRequestOperationType = 0 | 1 | 2;
+/**
+ * 0 同意入群, 1 拒绝入群, 2 忽略请求, 3 拒绝入群并添加黑名单，不再接收该用户的入群申请, 4 忽略入群并添加黑名单，不再接收该用户的入群申请
+ */
+export type MemberJoinRequestOperationType = 0 | 1 | 2 | 3 | 4;
+/**
+ * 1 同意邀请, 2 拒绝邀请
+ */
+export type BotInvitedJoinGroupRequestOperationType = 0 | 1;
+
+/**
  * https://github.com/project-mirai/mirai-api-http/blob/master/EventType.md
  * EventType 中的请求
  * resp.xxx 与 mirai-api-http URL 保持一致
@@ -26,12 +39,12 @@ export class Resp {
   /**
    * 响应新朋友请求
    * @param event 请求的事件
-   * @param operate 0 同意添加好友, 1 拒绝添加好友, 2 拒绝添加好友并添加黑名单，不再接收该用户的好友申请
+   * @param operate 操作：0 同意添加好友, 1 拒绝添加好友, 2 拒绝添加好友并添加黑名单，不再接收该用户的好友申请
    * @param message 响应消息
    */
   newFriendRequest(
     event: EventType.NewFriendRequestEvent,
-    operate: 0 | 1 | 2,
+    operate: NewFriendRequestOperationType,
     message = ""
   ) {
     return this._request(event, operate, message);
@@ -45,7 +58,7 @@ export class Resp {
    */
   memberJoinRequest(
     event: EventType.MemberJoinRequestEvent,
-    operate: 0 | 1 | 2 | 3 | 4,
+    operate: MemberJoinRequestOperationType,
     message = ""
   ) {
     return this._request(event, operate, message);
@@ -59,7 +72,7 @@ export class Resp {
    */
   botInvitedJoinGroupRequest(
     event: EventType.BotInvitedJoinGroupRequestEvent,
-    operate: 0 | 1,
+    operate: BotInvitedJoinGroupRequestOperationType,
     message = ""
   ) {
     return this._request(event, operate, message);

--- a/src/mirai-api-http/resp.ts
+++ b/src/mirai-api-http/resp.ts
@@ -45,7 +45,7 @@ export class Resp {
   newFriendRequest(
     event: EventType.NewFriendRequestEvent,
     operate: NewFriendRequestOperationType,
-    message = ""
+    message?: string
   ) {
     return this._request(event, operate, message);
   }
@@ -59,7 +59,7 @@ export class Resp {
   memberJoinRequest(
     event: EventType.MemberJoinRequestEvent,
     operate: MemberJoinRequestOperationType,
-    message = ""
+    message?: string
   ) {
     return this._request(event, operate, message);
   }
@@ -73,7 +73,7 @@ export class Resp {
   botInvitedJoinGroupRequest(
     event: EventType.BotInvitedJoinGroupRequestEvent,
     operate: BotInvitedJoinGroupRequestOperationType,
-    message = ""
+    message?: string
   ) {
     return this._request(event, operate, message);
   }

--- a/src/mirai.ts
+++ b/src/mirai.ts
@@ -311,9 +311,13 @@ export default class Mirai {
     };
 
     // 为请求类事件添加 respond 辅助函数
-    if (((e): e is EventType.RequestEvent => true)(msg)) {
+    if (
+      msg.type === "NewFriendRequestEvent" ||
+      msg.type === "MemberJoinRequestEvent" ||
+      msg.type === "BotInvitedJoinGroupRequestEvent"
+    ) {
       msg.respond = async (operate: any, message?: string) => {
-        this.api.resp.mapper[msg.type](msg as any, operate, message);
+        this.api.resp._request(msg, operate, message);
       };
     }
   }

--- a/src/mirai.ts
+++ b/src/mirai.ts
@@ -319,21 +319,21 @@ export default class Mirai {
     if (msg.type === "NewFriendRequestEvent") {
       msg.respond = async (
         operate: NewFriendRequestOperationType,
-        message = ""
+        message?: string
       ) => {
         this.api.resp.newFriendRequest(msg, operate, message);
       };
     } else if (msg.type === "MemberJoinRequestEvent") {
       msg.respond = async (
         operate: MemberJoinRequestOperationType,
-        message = ""
+        message?: string
       ) => {
         this.api.resp.memberJoinRequest(msg, operate, message);
       };
     } else if (msg.type === "BotInvitedJoinGroupRequestEvent") {
       msg.respond = async (
         operate: BotInvitedJoinGroupRequestOperationType,
-        message = ""
+        message?: string
       ) => {
         this.api.resp.botInvitedJoinGroupRequest(msg, operate, message);
       };

--- a/src/mirai.ts
+++ b/src/mirai.ts
@@ -288,7 +288,7 @@ export default class Mirai {
   }
 
   /**
-   * 为消息类型挂载辅助函数
+   * 为消息和事件类型挂载辅助函数
    * @param msg
    */
   addHelperForMsg(msg: MessageType.ChatMessage | EventType.Event) {
@@ -309,6 +309,13 @@ export default class Mirai {
     ) => {
       this.reply(msgChain, msg, quote);
     };
+
+    // 为请求类事件添加 respond 辅助函数
+    if (((e): e is EventType.RequestEvent => true)(msg)) {
+      msg.respond = async (operate: any, message?: string) => {
+        this.api.resp.mapper[msg.type](msg as any, operate, message);
+      };
+    }
   }
 
   /**

--- a/src/mirai.ts
+++ b/src/mirai.ts
@@ -11,6 +11,11 @@ import * as log from "./utils/log";
 import { getPlain } from "./utils";
 import { isMessage } from "./utils/check";
 import ora from "ora";
+import {
+  NewFriendRequestOperationType,
+  MemberJoinRequestOperationType,
+  BotInvitedJoinGroupRequestOperationType,
+} from "./mirai-api-http/resp";
 
 // 所有消息
 export type MessageAndEvent = MessageType.ChatMessage | EventType.Event;
@@ -311,13 +316,26 @@ export default class Mirai {
     };
 
     // 为请求类事件添加 respond 辅助函数
-    if (
-      msg.type === "NewFriendRequestEvent" ||
-      msg.type === "MemberJoinRequestEvent" ||
-      msg.type === "BotInvitedJoinGroupRequestEvent"
-    ) {
-      msg.respond = async (operate: any, message?: string) => {
-        this.api.resp._request(msg, operate, message);
+    if (msg.type === "NewFriendRequestEvent") {
+      msg.respond = async (
+        operate: NewFriendRequestOperationType,
+        message = ""
+      ) => {
+        this.api.resp.newFriendRequest(msg, operate, message);
+      };
+    } else if (msg.type === "MemberJoinRequestEvent") {
+      msg.respond = async (
+        operate: MemberJoinRequestOperationType,
+        message = ""
+      ) => {
+        this.api.resp.memberJoinRequest(msg, operate, message);
+      };
+    } else if (msg.type === "BotInvitedJoinGroupRequestEvent") {
+      msg.respond = async (
+        operate: BotInvitedJoinGroupRequestOperationType,
+        message = ""
+      ) => {
+        this.api.resp.botInvitedJoinGroupRequest(msg, operate, message);
       };
     }
   }

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -5,6 +5,7 @@
 
 import * as Contact from "./contact";
 import { MessageChain } from "./message-type";
+import { RequestEventOperation } from "../mirai-api-http/resp";
 
 /**
  * 内部基类
@@ -277,7 +278,6 @@ export interface MemberUnmuteEvent extends BaseEvent {
  */
 export interface NewFriendRequestEvent extends BaseRequestEvent {
   type: "NewFriendRequestEvent";
-  operations: ["allow", "deny", "black"];
   eventId: number;
   fromId: number;
   groupId: number;
@@ -290,7 +290,6 @@ export interface NewFriendRequestEvent extends BaseRequestEvent {
  */
 export interface MemberJoinRequestEvent extends BaseRequestEvent {
   type: "MemberJoinRequestEvent";
-  operations: ["allow", "deny", "ignore", "deny-black", "ignore-black"];
   eventId: number;
   fromId: number;
   groupId: number;
@@ -304,7 +303,6 @@ export interface MemberJoinRequestEvent extends BaseRequestEvent {
  */
 export interface BotInvitedJoinGroupRequestEvent extends BaseRequestEvent {
   type: "BotInvitedJoinGroupRequestEvent";
-  operations: ["allow", "deny"];
   eventId: number;
   fromId: number;
   groupId: number;
@@ -314,9 +312,9 @@ export interface BotInvitedJoinGroupRequestEvent extends BaseRequestEvent {
 }
 
 interface BaseRequestEvent extends BaseEvent {
-  operations: string[];
+  type: any;
   respond: (
-    operate: this["operations"][number],
+    operate: RequestEventOperation<this["type"]>,
     message?: string
   ) => Promise<void>;
 }

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -5,6 +5,11 @@
 
 import * as Contact from "./contact";
 import { MessageChain } from "./message-type";
+import {
+  NewFriendRequestOperationType,
+  MemberJoinRequestOperationType,
+  BotInvitedJoinGroupRequestOperationType,
+} from "src/mirai-api-http/resp";
 
 /**
  * 内部基类
@@ -276,7 +281,10 @@ export interface MemberUnmuteEvent extends BaseEvent {
  * 基础请求事件格式
  */
 interface BaseRequestEvent extends BaseEvent {
-  respond: (operate: 0 | 1 | 2 | 3 | 4, message?: string) => Promise<void>;
+  /**
+   * 事件标识，响应该事件时的标识
+   */
+  eventId: number;
 }
 
 /**
@@ -285,15 +293,11 @@ interface BaseRequestEvent extends BaseEvent {
 export interface NewFriendRequestEvent extends BaseRequestEvent {
   type: "NewFriendRequestEvent";
   /**
-   * 事件标识，响应该事件时的标识
-   */
-  eventId: number;
-  /**
    * 申请人QQ号
    */
   fromId: number;
   /**
-   * 申请人如果通过某个群添加好友，该项为该群群号；否则为0
+   * 申请人如果通过某个群添加好友，该项为该群群号；否则为 0
    */
   groupId: number;
   /**
@@ -304,6 +308,10 @@ export interface NewFriendRequestEvent extends BaseRequestEvent {
    * 申请消息
    */
   message: string;
+  respond: (
+    operate: NewFriendRequestOperationType,
+    message?: string
+  ) => Promise<void>;
 }
 
 /**
@@ -312,11 +320,7 @@ export interface NewFriendRequestEvent extends BaseRequestEvent {
 export interface MemberJoinRequestEvent extends BaseRequestEvent {
   type: "MemberJoinRequestEvent";
   /**
-   * 事件标识，响应该事件时的标识
-   */
-  eventId: number;
-  /**
-   * 申请人QQ号
+   * 申请人 QQ号
    */
   fromId: number;
   /**
@@ -335,6 +339,10 @@ export interface MemberJoinRequestEvent extends BaseRequestEvent {
    * 申请消息
    */
   message: string;
+  respond: (
+    operate: MemberJoinRequestOperationType,
+    message?: string
+  ) => Promise<void>;
 }
 
 /**
@@ -343,11 +351,7 @@ export interface MemberJoinRequestEvent extends BaseRequestEvent {
 export interface BotInvitedJoinGroupRequestEvent extends BaseRequestEvent {
   type: "BotInvitedJoinGroupRequestEvent";
   /**
-   * 事件标识，响应该事件时的标识
-   */
-  eventId: number;
-  /**
-   * 邀请人（好友）的QQ号
+   * 邀请人（好友）的 QQ号
    */
   fromId: number;
   /**
@@ -366,6 +370,10 @@ export interface BotInvitedJoinGroupRequestEvent extends BaseRequestEvent {
    * 邀请消息
    */
   message: string;
+  respond: (
+    operate: BotInvitedJoinGroupRequestOperationType,
+    message?: string
+  ) => Promise<void>;
 }
 
 export type RequestEvent =

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -275,8 +275,9 @@ export interface MemberUnmuteEvent extends BaseEvent {
 /**
  * 添加好友申请
  */
-export interface NewFriendRequestEvent extends BaseEvent {
+export interface NewFriendRequestEvent extends BaseRequestEvent {
   type: "NewFriendRequestEvent";
+  operations: ["allow", "deny", "black"];
   eventId: number;
   fromId: number;
   groupId: number;
@@ -287,8 +288,9 @@ export interface NewFriendRequestEvent extends BaseEvent {
 /**
  * 用户入群申请（Bot需要有管理员权限）
  */
-export interface MemberJoinRequestEvent extends BaseEvent {
+export interface MemberJoinRequestEvent extends BaseRequestEvent {
   type: "MemberJoinRequestEvent";
+  operations: ["allow", "deny", "ignore", "deny-black", "ignore-black"];
   eventId: number;
   fromId: number;
   groupId: number;
@@ -300,8 +302,9 @@ export interface MemberJoinRequestEvent extends BaseEvent {
 /**
  * Bot被邀请入群申请
  */
-export interface BotInvitedJoinGroupRequestEvent extends BaseEvent {
+export interface BotInvitedJoinGroupRequestEvent extends BaseRequestEvent {
   type: "BotInvitedJoinGroupRequestEvent";
+  operations: ["allow", "deny"];
   eventId: number;
   fromId: number;
   groupId: number;
@@ -309,6 +312,19 @@ export interface BotInvitedJoinGroupRequestEvent extends BaseEvent {
   nick: string;
   message: string;
 }
+
+interface BaseRequestEvent extends BaseEvent {
+  operations: string[];
+  respond: (
+    operate: this["operations"][number],
+    message?: string
+  ) => Promise<void>;
+}
+
+export type RequestEvent =
+  | NewFriendRequestEvent
+  | MemberJoinRequestEvent
+  | BotInvitedJoinGroupRequestEvent;
 
 export type Event =
   | BotOnlineEvent

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -5,7 +5,6 @@
 
 import * as Contact from "./contact";
 import { MessageChain } from "./message-type";
-import { RequestEventOperation } from "../mirai-api-http/resp";
 
 /**
  * 内部基类
@@ -274,14 +273,36 @@ export interface MemberUnmuteEvent extends BaseEvent {
 }
 
 /**
+ * 基础请求事件格式
+ */
+interface BaseRequestEvent extends BaseEvent {
+  respond: (operate: 0 | 1 | 2 | 3 | 4, message?: string) => Promise<void>;
+}
+
+/**
  * 添加好友申请
  */
 export interface NewFriendRequestEvent extends BaseRequestEvent {
   type: "NewFriendRequestEvent";
+  /**
+   * 事件标识，响应该事件时的标识
+   */
   eventId: number;
+  /**
+   * 申请人QQ号
+   */
   fromId: number;
+  /**
+   * 申请人如果通过某个群添加好友，该项为该群群号；否则为0
+   */
   groupId: number;
+  /**
+   * 	申请人的昵称或群名片
+   */
   nick: string;
+  /**
+   * 申请消息
+   */
   message: string;
 }
 
@@ -290,11 +311,29 @@ export interface NewFriendRequestEvent extends BaseRequestEvent {
  */
 export interface MemberJoinRequestEvent extends BaseRequestEvent {
   type: "MemberJoinRequestEvent";
+  /**
+   * 事件标识，响应该事件时的标识
+   */
   eventId: number;
+  /**
+   * 申请人QQ号
+   */
   fromId: number;
+  /**
+   * 申请人申请入群的群号
+   */
   groupId: number;
+  /**
+   * 申请人申请入群的群名称
+   */
   groupName: string;
+  /**
+   * 申请人的昵称或群名片
+   */
   nick: string;
+  /**
+   * 申请消息
+   */
   message: string;
 }
 
@@ -303,20 +342,30 @@ export interface MemberJoinRequestEvent extends BaseRequestEvent {
  */
 export interface BotInvitedJoinGroupRequestEvent extends BaseRequestEvent {
   type: "BotInvitedJoinGroupRequestEvent";
+  /**
+   * 事件标识，响应该事件时的标识
+   */
   eventId: number;
+  /**
+   * 邀请人（好友）的QQ号
+   */
   fromId: number;
+  /**
+   * 被邀请进入群的群号
+   */
   groupId: number;
+  /**
+   * 被邀请进入群的群名称
+   */
   groupName: string;
+  /**
+   * 邀请人（好友）的昵称
+   */
   nick: string;
+  /**
+   * 邀请消息
+   */
   message: string;
-}
-
-interface BaseRequestEvent extends BaseEvent {
-  type: any;
-  respond: (
-    operate: RequestEventOperation<this["type"]>,
-    message?: string
-  ) => Promise<void>;
 }
 
 export type RequestEvent =
@@ -386,6 +435,7 @@ export type EventMap = {
   MemberPermissionChangeEvent: MemberPermissionChangeEvent;
   MemberMuteEvent: MemberMuteEvent;
   MemberUnmuteEvent: MemberUnmuteEvent;
+  // 请求事件
   NewFriendRequestEvent: NewFriendRequestEvent;
   MemberJoinRequestEvent: MemberJoinRequestEvent;
   BotInvitedJoinGroupRequestEvent: BotInvitedJoinGroupRequestEvent;


### PR DESCRIPTION
之前说的“类比 reply，快速响应请求类事件”。
折腾了几个小时才摸索出实现类型约束，同时又相对简洁的实现方式。

让我最吃惊的是，TypeScript 竟然会在匿名定义公开类成员的类型时，将函数类型参数的可见性保持为私有，导致我需要写两遍 `EventType.EventMap[type]`，而不能像后面一样直接用 `typeof event` 代替。（其实一开始打算用 Record，但是没有办法使 Record 两端的类型相关联。另外我肯定是不想用函数实现的，能静态就尽量静态。）

其实本想直接将 respond 一起做到 api 命名空间去（同样类比 reply），但在实现类型约束时碰到问题（对函数参数 1 的类型检查无法同时转移到参数 2 身上，也无法直接把两个参数的类型直接绑定，因为 typeof 是在编译时求值），况且涉及的方法并不很多，直接调用简单封装的 API 比较直观，所以做成了现在这个样子。

判断事件子类型用了自定义 type guard 的方式，我不知道有没有更优雅的方式，但是至少还是比较简洁的。

最后是 Resp 类的 api 成员应该改作私有，毕竟它本身不应该独立于 API 存在，不应该在子类中直接暴露出父类来。