### PR TITLE
fix: WebSocket 连接被忽略

### DIFF
--- a/src/mirai-api-http/index.ts
+++ b/src/mirai-api-http/index.ts
@@ -577,6 +577,10 @@ export default class MiraiApiHttp {
     const ws = new WebSocket(
       this.address + "/message?sessionKey=" + this.sessionKey
     );
+    ws.on("open", () => {
+      const interval = setInterval(() => ws.ping(), 60000);
+      ws.on("close", () => clearInterval(interval));
+    });
     ws.on("message", (data: WebSocket.Data) => {
       const msg = JSON.parse(data.toString());
       callback(msg);
@@ -592,6 +596,10 @@ export default class MiraiApiHttp {
     const ws = new WebSocket(
       this.address + "/event?sessionKey=" + this.sessionKey
     );
+    ws.on("open", () => {
+      const interval = setInterval(() => ws.ping(), 60000);
+      ws.on("close", () => clearInterval(interval));
+    });
     ws.on("message", (data: WebSocket.Data) => {
       const msg = JSON.parse(data.toString());
       callback(msg);
@@ -607,6 +615,10 @@ export default class MiraiApiHttp {
     const ws = new WebSocket(
       this.address + "/all?sessionKey=" + this.sessionKey
     );
+    ws.on("open", () => {
+      const interval = setInterval(() => ws.ping(), 60000);
+      ws.on("close", () => clearInterval(interval));
+    });
     ws.on("message", (data: WebSocket.Data) => {
       const msg = JSON.parse(data.toString());
       callback(msg);


### PR DESCRIPTION
这个是 mirai-api-http 的问题，未收到任何消息几分钟后，该 WebSocket 连接会被服务端忽略。

具体的 issue 在这 -> [mirai-api-http#255](https://github.com/project-mirai/mirai-api-http/issues/255)。

我在每个监听消息处定时 (60s) 对服务端发送 ping，并在 ws close 后关闭该定时器，经过本地测试运行良好。

已实现的 -> [Mirai-js/master/src/core/startListening.js](https://github.com/Drincann/Mirai-js/blob/master/src/core/startListening.js)。
