### PR TITLE
🐛 fix axios body max length limit

### DIFF
--- a/src/mirai-api-http/index.ts
+++ b/src/mirai-api-http/index.ts
@@ -63,6 +63,8 @@ export default class MiraiApiHttp {
     const httpSetting = this.setting.adapterSettings.http;
     this.address = `http://${httpSetting.host}:${httpSetting.port}`;
     this.axios.defaults.baseURL = this.address;
+    this.axios.defaults.maxContentLength = Infinity;
+    this.axios.defaults.maxBodyLength = Infinity;
 
     this.command = new Command(this);
     this.resp = new Resp(this);


### PR DESCRIPTION
如果用 `base64` 的方式发送图片，在图片较大时会报错 `Request body larger than maxBodyLength limit`。

解决方法是将 `axios` 的 `maxContentLength` 属性与 `maxBodyLength` 属性的默认值设置为 `Infinity`。