### PR TITLE
:bug: downgrade chalk for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirai-ts",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Mirai TypeScript SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -65,7 +65,7 @@
   "dependencies": {
     "@yunyoujun/logger": "^0.1.4",
     "axios": "^0.24.0",
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.2",
     "form-data": "^4.0.0",
     "ws": "^8.3.0"
   }


### PR DESCRIPTION
尝试使用`ts-node`跑的时候报了下面的错误，发现`2.1.1`升级了`chalk`的版本。
```
[INFO] 22:30:43 ts-node-dev ver. 1.1.8 (using ts-node ver. 9.1.1, typescript ver. 4.5.2)
Error [ERR_REQUIRE_ESM]: require() of ES Module **\node_modules\mirai-ts\node_modules\chalk\source\index.js from **\node_modules\mirai-ts\dist\mirai.js not supported.
Instead change the require of index.js in **\node_modules\mirai-ts\dist\mirai.js to a dynamic import() which is available in all CommonJS modules.
```
根据`chalk 5.0.0`的[Release Notes](https://github.com/chalk/chalk/releases/tag/v5.0.0)
> This package is now pure ESM. Please read [this](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
> - If you use TypeScript, you will want to stay on Chalk 4 until TypeScript 4.6 is out. [Why](https://github.com/microsoft/TypeScript/issues/46452).
> - If you use a bundler, make sure it supports ESM and that you have correctly configured it for ESM.
> - The Chalk issue tracker is not a support channel for your favorite build/bundler tool.

目前应该继续使用`4.1.2`