### PR TITLE
:bug: fix route path of command system, add missed command event.

### DIFF
--- a/src/mirai-api-http/command.ts
+++ b/src/mirai-api-http/command.ts
@@ -26,7 +26,7 @@ export class Command {
    * - 当指令通过其他方式发送时，如控制台、HTTP 接口等，sender 和 group 均为 0
    */
   async listen(): Promise<CommandInfo> {
-    const { data } = (await this.api.axios.post('/command', {
+    const { data } = (await this.api.axios.post('/cmd', {
       verifyKey: this.api.setting.verifyKey,
     })) as AxiosResponse<CommandInfo>
     return data
@@ -45,7 +45,7 @@ export class Command {
     description: string,
     usage?: string,
   ) {
-    const { data } = await this.api.axios.post('/command/register', {
+    const { data } = await this.api.axios.post('/cmd/register', {
       verifyKey: this.api.setting.verifyKey,
       name,
       alias,
@@ -60,8 +60,8 @@ export class Command {
    * @param name 指令名
    * @param args 指令参数
    */
-  async send(name: string, args: string[]) {
-    const { data } = await this.api.axios.post('/command/send', {
+  async execute(name: string, args: string[]) {
+    const { data } = await this.api.axios.post('/cmd/execute', {
       verifyKey: this.api.setting.verifyKey,
       name,
       args,

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -10,7 +10,7 @@ import type {
 } from '../mirai-api-http/resp'
 import type { Api } from '../index'
 import type * as Contact from './contact'
-import type { MessageChain } from './message-type'
+import type { MessageType } from './message-type'
 
 /**
  * 内部基类
@@ -20,7 +20,7 @@ export interface BaseEvent {
   /**
    * reply 辅助函数
    */
-  reply?: (msgChain: string | MessageChain, quote?: boolean) => Promise<void>
+  reply?: (msgChain: string | MessageType.MessageChain, quote?: boolean) => Promise<void>
 }
 
 /**
@@ -434,7 +434,7 @@ export interface CommandExecutedEvent extends BaseEvent {
   /**
    * 指令的参数, 以消息类型传递
    */
-  args: MessageChain
+  args: MessageType.MessageChain
   reply?: undefined
 }
 

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -420,20 +420,20 @@ export interface NudgeEvent extends BaseEvent {
 export interface CommandExecutedEvent extends BaseEvent {
   type: 'CommandExecutedEvent'
   /**
-  * 命令名称
-  */
+   * 命令名称
+   */
   name: string
   /**
-  * 发送命令的好友, 从控制台发送为 null
-  */
+   * 发送命令的好友, 从控制台发送为 null
+   */
   friend: Contact.Friend | null
   /**
-  * 发送命令的群成员, 从控制台发送为 null
-  */
+   * 发送命令的群成员, 从控制台发送为 null
+   */
   member: Contact.Member | null
   /**
-  * 指令的参数, 以消息类型传递
-  */
+   * 指令的参数, 以消息类型传递
+   */
   args: MessageChain
   reply?: undefined
 }

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -417,6 +417,27 @@ export interface NudgeEvent extends BaseEvent {
   }
 }
 
+export interface CommandExecutedEvent extends BaseEvent {
+  type: 'CommandExecutedEvent'
+  /**
+  * 命令名称
+  */
+  name: string
+  /**
+  * 发送命令的好友, 从控制台发送为 null
+  */
+  friend: Contact.Friend | null
+  /**
+  * 发送命令的群成员, 从控制台发送为 null
+  */
+  member: Contact.Member | null
+  /**
+  * 指令的参数, 以消息类型传递
+  */
+  args: MessageChain
+  reply?: undefined
+}
+
 export interface EventMap {
   BotOnlineEvent: BotOnlineEvent
   BotOfflineEventActive: BotOfflineEventActive
@@ -451,6 +472,9 @@ export interface EventMap {
   BotInvitedJoinGroupRequestEvent: BotInvitedJoinGroupRequestEvent
 
   NudgeEvent: NudgeEvent
+
+  // 命令事件
+  CommandExecutedEvent: CommandExecutedEvent
 }
 
 // string union of event type


### PR DESCRIPTION
想要尝试一下command相关的接口，发现现在的支持有问题
根据源文件 [mirai-http-api paths.kt](https://github.com/project-mirai/mirai-api-http/blob/master/mirai-api-http/src/main/kotlin/net/mamoe/mirai/api/http/adapter/internal/consts/paths.kt#L71) ，mirai-api-http 的 comand 的接口路由现在是 `cmd` 开始，下面有 `cmd/register` 和 `cmd/execute` ，修改于15个月前
而 mirai-ts 的实现中，相关接口仍然写的是 `command/register` 和 `command/send` ，所以修复了路由，同时把 `Command.send` 接口名字也改成了 `Command.execute` 保证一致
另外 `EventMap` 中缺乏 `CommandExecute` 事件，导致 mirai-api-http 转发的接口调用事件（参考[mirai-http-api api event](https://github.com/project-mirai/mirai-api-http/blob/master/docs/api/EventType.md#%E5%91%BD%E4%BB%A4%E8%A2%AB%E6%89%A7%E8%A1%8C)）没法直接监听，所以补上了这部分。